### PR TITLE
Fix first click toggle toggleMenu

### DIFF
--- a/js/toggleMenu.js
+++ b/js/toggleMenu.js
@@ -1,14 +1,22 @@
+
+
 function toggleMenu() {
-    var x = document.getElementById("toggleMenu");
+    var element = document.getElementById("toggleMenu");
+    var elementStyles = window.getComputedStyle(element)
+    var displayType = elementStyles.display
+    console.log(displayType)
     
-    if(x.style.display === "none") {
-        x.style.display = "flex"
+    if(displayType === "none") {
+        element.style.display = "flex"
     }
     else {
-        x.style.display = "none"
+        element.style.display = "none"
     }    
 }
 
+
+
+// This function works perfectly. It's very simple too.
 let gear = document.getElementById("settings-icon")
 gear.onclick = function() {
     toggleMenu()


### PR DESCRIPTION
At first page load, two clicks were needed to toggle the menu. getComputedStyle is now used to make sure to have the value before running the if statement.