### PR TITLE
Fix positioning of toggleMenu

### DIFF
--- a/css/toggleMenu.css
+++ b/css/toggleMenu.css
@@ -9,8 +9,7 @@
     gap: 13em;
     border-radius: 1em;
     position: absolute;
-    left: 100%;
-    transform: translate(-200%, 0);
+    right: 160px;
     z-index: 1;
 }
 


### PR DESCRIPTION
Changed the positioning values.
Got rid of left and added right: 160px:
Removed the transform. It wasn't necessary.
The positioning is still absolute for it.